### PR TITLE
fixed 3 slope apr calculation code

### DIFF
--- a/x/lendingpool/interestmodels/tripleslope/model.go
+++ b/x/lendingpool/interestmodels/tripleslope/model.go
@@ -32,8 +32,7 @@ func (ts TripleSlope) GetAPR(utilizationRate sdk.Dec) sdk.Dec {
 		}
 	}
 
-	// not assuming there are 3 slopes
-	return ts.Params.M[len(ts.Params.R)-1].Mul(utilizationRate).Add(ts.Params.B[len(ts.Params.R)-1])
+	return ts.Params.M[len(ts.Params.R)].Mul(utilizationRate).Add(ts.Params.B[len(ts.Params.R)])
 }
 
 func (ts TripleSlope) ModelType() string {


### PR DESCRIPTION
## 수정된 버그
- [x] LendingPool 가동률에 따른 금리 구할 때 3 Slope 구간에서 기대되는 m, b 값을 잘못된 index 로 2 Slope 값을 가져오는 현상 해결