### PR TITLE
added divisision validated codes & fixed update redemption case

### DIFF
--- a/x/lendingpool/abci.go
+++ b/x/lendingpool/abci.go
@@ -17,6 +17,7 @@ func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k keeper.Keeper) 
 		if apr.Equal(sdk.ZeroDec()) {
 			continue
 		}
+		// Default Setting 값이 0 이 아니기 때문에 division by zero 에 대한 문제 없음
 		loanInterest := apr.Quo(sdk.NewDec(int64(yearBlocks)))
 
 		blockInterest := loanInterest.Mul(p.GetUtilizationRate())
@@ -45,6 +46,7 @@ func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k keeper.Keeper) 
 				if i == len(loans)-1 {
 					entryInterest = interest
 				} else {
+					// totalBorrow 가 0 인 경우는 연출되지 않는다.
 					entryInterest = interest.Mul(l.BorrowedValue).Quo(totalBorrow)
 					interest = interest.Sub(entryInterest)
 				}

--- a/x/lendingpool/keeper/deposit.go
+++ b/x/lendingpool/keeper/deposit.go
@@ -14,6 +14,10 @@ func (k Keeper) Deposit(ctx sdk.Context, msg types.MsgDeposit) (types.MsgDeposit
 		return types.MsgDepositResponse{}, types.ErrPoolNotFound
 	}
 
+	if pool.RedemptionRate.Equal(sdk.ZeroDec()) {
+		return types.MsgDepositResponse{}, types.ErrDivisionByZero
+	}
+
 	exchangeRate := pool.RedemptionRate
 
 	// assume inputting base tokens for now, e.g. msg.Amount = XXXuevmos

--- a/x/lendingpool/types/errors.go
+++ b/x/lendingpool/types/errors.go
@@ -24,4 +24,5 @@ var (
 	ErrOverflowMaxDebtRatio   = errorsmod.Register(ModuleName, 216, "Overflow the max debt ratio")
 	ErrInvalidRedemptionRate  = errorsmod.Register(ModuleName, 217, "Invalid redemption rate")
 	ErrFailedLiquidate        = errorsmod.Register(ModuleName, 218, "Failed to liquidate position")
+	ErrDivisionByZero         = errorsmod.Register(ModuleName, 219, "Failed to divide by zero")
 )

--- a/x/levstakeibc/keeper/host_zone.go
+++ b/x/levstakeibc/keeper/host_zone.go
@@ -56,6 +56,11 @@ func (k Keeper) UpdateRedemptionRates(ctx sdk.Context, depositRecords []recordst
 		redemptionRate := (sdk.NewDecFromInt(undelegatedBalance).Add(sdk.NewDecFromInt(stakedBalance)).Add(sdk.NewDecFromInt(moduleAcctBalance))).Quo(sdk.NewDecFromInt(stSupply))
 		k.Logger(ctx).Info(utils.LogWithHostZone(hostZone.ChainId, "New Redemption Rate: %v (vs Prev Rate: %v)", redemptionRate, hostZone.RedemptionRate))
 
+		if redemptionRate.LT(sdk.OneDec()) {
+			redemptionRate = sdk.OneDec()
+			k.Logger(ctx).Info(utils.LogWithHostZone(hostZone.ChainId, "Redemption Rate is less than 1.00000, so forcing to adjust %v", redemptionRate))
+		}
+
 		// Update the host zone
 		hostZone.LastRedemptionRate = hostZone.RedemptionRate
 		hostZone.RedemptionRate = redemptionRate

--- a/x/levstakeibc/keeper/keeper.go
+++ b/x/levstakeibc/keeper/keeper.go
@@ -227,8 +227,14 @@ func (k Keeper) GetTargetValAmtsForHostZone(ctx sdk.Context, hostZone types.Host
 		if i == len(validators)-1 {
 			targetUnbondingsByValidator[validator.Address] = finalDelegation.Sub(totalAllocated)
 		} else {
+			_totalWeight := sdk.NewIntFromUint64(totalWeight)
+
+			if _totalWeight.Equal(sdk.NewInt(0)) {
+				_totalWeight = sdk.NewInt(1)
+			}
+
 			// 여기는 validator 하나 이기 때문에 안탄다...
-			delegateAmt := sdk.NewIntFromUint64(validator.Weight).Mul(finalDelegation).Quo(sdk.NewIntFromUint64(totalWeight))
+			delegateAmt := sdk.NewIntFromUint64(validator.Weight).Mul(finalDelegation).Quo(_totalWeight)
 			totalAllocated = totalAllocated.Add(delegateAmt)
 			targetUnbondingsByValidator[validator.Address] = delegateAmt
 		}

--- a/x/levstakeibc/keeper/msg_rebalance_validators.go
+++ b/x/levstakeibc/keeper/msg_rebalance_validators.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
 	admintypes "github.com/soohoio/stayking/v2/x/admin/types"
 	epochstypes "github.com/soohoio/stayking/v2/x/epochs/types"
@@ -71,16 +72,16 @@ func (k msgServer) RebalanceValidators(goCtx context.Context, msg *types.MsgReba
 	underWeightIndex := len(valDeltaList) - 1
 
 	// check if there is a large enough rebalance, if not, just exit
-	total_delegation := k.GetTotalValidatorDelegations(hostZone)
-	if total_delegation.IsZero() {
-		return nil, sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "no validator delegations found for Host Zone %s, cannot rebalance 0 delegations!", hostZone.ChainId)
+	totalDelegation := k.GetTotalValidatorDelegations(hostZone)
+	if totalDelegation.IsZero() {
+		return nil, errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "no validator delegations found for Host Zone %s, cannot rebalance 0 delegations!", hostZone.ChainId)
 	}
 
-	overweight_delta := sdk.NewDecFromInt(valDeltaList[overWeightIndex].deltaAmt).Quo(sdk.NewDecFromInt(total_delegation))
-	underweight_delta := sdk.NewDecFromInt(valDeltaList[underWeightIndex].deltaAmt).Quo(sdk.NewDecFromInt(total_delegation))
-	max_delta := sdk.MaxDec(overweight_delta, underweight_delta)
+	overweightDelta := sdk.NewDecFromInt(valDeltaList[overWeightIndex].deltaAmt).Quo(sdk.NewDecFromInt(totalDelegation))
+	underweightDelta := sdk.NewDecFromInt(valDeltaList[underWeightIndex].deltaAmt).Quo(sdk.NewDecFromInt(totalDelegation))
+	maxDelta := sdk.MaxDec(overweightDelta, underweightDelta)
 	rebalanceThreshold := sdk.NewDec(int64(k.GetParam(ctx, types.KeyValidatorRebalancingThreshold))).Quo(sdk.NewDec(10000))
-	if max_delta.LT(rebalanceThreshold) {
+	if maxDelta.LT(rebalanceThreshold) {
 		k.Logger(ctx).Error("Not enough validator disruption to rebalance")
 		return nil, types.ErrWeightsNotDifferent
 	}
@@ -89,7 +90,7 @@ func (k msgServer) RebalanceValidators(goCtx context.Context, msg *types.MsgReba
 	delegationIca := hostZone.GetDelegationAccount()
 	if delegationIca == nil || delegationIca.GetAddress() == "" {
 		k.Logger(ctx).Error(fmt.Sprintf("Zone %s is missing a delegation address!", hostZone.ChainId))
-		return nil, sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "Invalid delegation account")
+		return nil, errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "Invalid delegation account")
 	}
 
 	delegatorAddress := delegationIca.GetAddress()
@@ -170,7 +171,7 @@ func (k msgServer) RebalanceValidators(goCtx context.Context, msg *types.MsgReba
 	connectionId := hostZone.GetConnectionId()
 	_, err = k.SubmitTxsEpoch(ctx, connectionId, msgs, *hostZone.GetDelegationAccount(), epochstypes.STAYKING_EPOCH, ICACallbackID_Rebalance, marshalledCallbackArgs)
 	if err != nil {
-		return nil, sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "Failed to SubmitTxs for %s, %s, %s, %s", connectionId, hostZone.ChainId, msgs, err.Error())
+		return nil, errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "Failed to SubmitTxs for %s, %s, %s, %s", connectionId, hostZone.ChainId, msgs, err.Error())
 	}
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(


### PR DESCRIPTION
- [x] lendingpool & levstakeibc 모듈에서 잠재적 division by zero panic 상황에 대한 코드 조치
- [x] update redemption rate 가 계산될 때 new redemption rate 값이 < 1.000000 인 경우 1.000000 으로 맞춘다.  